### PR TITLE
Only print "CPU fan high" message once

### DIFF
--- a/PID_fan_control.pl
+++ b/PID_fan_control.pl
@@ -1111,8 +1111,11 @@ sub decide_cpu_fan_level
     
     if ($cpu_fan_override == 1)
     {
-        $cpu_fan = "high";
-        dprint( 0, "CPU fan set to high to help cool HDs.\n");
+        if( $cpu_fan ne "high" )
+        {
+            $cpu_fan = "high";
+            dprint( 0, "CPU fan set to high to help cool HDs.\n");
+        }
     }
     else
     {


### PR DESCRIPTION
When my CPU fan needed to help out cooling the HDs, the message was printed every few seconds. This patch makes it print only once.